### PR TITLE
Remove abstract constructor requirement in UseAssetConnectTrait

### DIFF
--- a/src/AssetConnect.php
+++ b/src/AssetConnect.php
@@ -17,7 +17,6 @@ use Maniaba\AssetConnect\Exceptions\InvalidArgumentException;
 use Maniaba\AssetConnect\Models\AssetModel;
 use Maniaba\AssetConnect\Traits\UseAssetConnectTrait;
 use RuntimeException;
-use stdClass;
 
 final class AssetConnect
 {

--- a/src/Traits/UseAssetConnectTrait.php
+++ b/src/Traits/UseAssetConnectTrait.php
@@ -28,6 +28,7 @@ use Maniaba\AssetConnect\Exceptions\InvalidArgumentException;
 trait UseAssetConnectTrait
 {
     private AssetConnect $assetConnectInstance;
+
     /**
      * Initialize the asset connection for this entity
      *

--- a/src/Traits/UseAssetConnectTrait.php
+++ b/src/Traits/UseAssetConnectTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Maniaba\AssetConnect\Traits;
 
-use CodeIgniter\Entity\Entity;
 use CodeIgniter\Files\File;
 use CodeIgniter\HTTP\Files\UploadedFile;
 use Config\Services;

--- a/src/Traits/UseAssetConnectTrait.php
+++ b/src/Traits/UseAssetConnectTrait.php
@@ -29,12 +29,6 @@ use Maniaba\AssetConnect\Exceptions\InvalidArgumentException;
 trait UseAssetConnectTrait
 {
     private AssetConnect $assetConnectInstance;
-
-    /**
-     * Ensure that classes using this trait implement the required interface
-     */
-    abstract public function __construct();
-
     /**
      * Initialize the asset connection for this entity
      *

--- a/tests/Asset/AssetTest.php
+++ b/tests/Asset/AssetTest.php
@@ -69,9 +69,7 @@ final class AssetTest extends CIUnitTestCase
     public function testSetEntityTypeWithEntityInstance(): void
     {
         // Arrange
-        $this->mockEntity = $this->getMockBuilder(Entity::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->mockEntity = $this->createMock(Entity::class);
 
         // Act
         $result = $this->asset->setEntityType($this->mockEntity);


### PR DESCRIPTION
The `abstract constructor` requirement has been removed from `UseAssetConnectTrait` to enhance flexibility and allow non-abstract implementations to make use of the trait.